### PR TITLE
Changed PozyxSerial class to close port when sent out of context. You…

### DIFF
--- a/pypozyx/serial.py
+++ b/pypozyx/serial.py
@@ -11,6 +11,18 @@ import time
 
 class PozyxSerial(PozyxLib):
 
+    def __enter__(self):
+        return self
+
+    def __exit__(self,exc_type,exc_value,traceback):
+        count = 0
+        while (self.ser.is_open and count < 100):
+            self.ser.close()
+            count += 1
+        if self.ser.is_open:
+            print("ERROR: Serial port failed to close")
+            return POZYX_FAILURE
+
     def __init__(self, port, baudrate=115200, timeout=0.2, mode=MODE_POLLING, print_output=False):
         self.print_output = print_output
         self.ser = serial.Serial(port, baudrate, timeout=timeout)


### PR DESCRIPTION
… must generate a PozyxSerial instance using the "with" token now.

I noticed that the PozyxSerial class was not closing its port when the program exited due to SystemExit being raised, the user closing the console, or the program finishing its execution.

I added an **enter** and an **exit** function to PozyxSerial, which causes the Python program to call **enter** upon constructing an instance of PozyxSerial and **exit** when the instance goes out of context.
One must use the "with... as..." syntax in order to make use of PozyxSerial in this way.
For example:

```
port = 'COM3'
__init__(self):
    with PozyxSerial(port) as pozyx:
        self.setup()

setup():
    # some code
```

I tested this new version of PozyxSerial with the attached python script (converted to a .txt for the purpose of uploading directly to this message), and it appeared functional.
[connect_remote.txt](https://github.com/pozyxLabs/Pozyx-Python-library/files/477559/connect_remote.txt)

Also, hi Laurent! You said for me to contribute if I come up with something, so here I am.
