### PR TITLE
Fix typo in docstrings of Data class

### DIFF
--- a/pypozyx/structures/generic.py
+++ b/pypozyx/structures/generic.py
@@ -155,7 +155,7 @@ class Data(ByteStructure):
     ---------------
     Data creates a packed data structure with size and format that is entirely the user's choice.
     The format follows the one used in struct, where b is a byte, h is a 2-byte int, and
-    i is a default-sized integer, and f is a float. In capitals, these are signed.
+    i is a default-sized integer, and f is a float. In capitals, these are unsigned.
     So, to create a custom construct consisting of 4 uint16 and a single int, the
     following code can be used.
 


### PR DESCRIPTION
There is a typo in the docstrings of the Data class. It states that in capitals the data format is signed, but according to the example just a few lines below, capitals mean unsigned.

    In capitals, these are signed. So, to create a custom construct consisting of 4 uint16 and a single int, the
    following code can be used.

     >>> d = Data([0] * 5, 'HHHHi')