### PR TITLE
Fix for linux where it fails on init of PozyxSerial() and fix for denormalized quaternion

### DIFF
--- a/pypozyx/lib.py
+++ b/pypozyx/lib.py
@@ -2,7 +2,7 @@
 """pypozyx.lib - Contains core and extended Pozyx user functionality through the PozyxLib class."""
 
 from time import sleep
-
+from math import sqrt,pow
 from pypozyx.core import PozyxCore
 from pypozyx.definitions.bitmasks import *
 from pypozyx.definitions.constants import *
@@ -1155,7 +1155,15 @@ class PozyxLib(PozyxCore):
         Returns:
             POZYX_SUCCESS, POZYX_FAILURE, POZYX_TIMEOUT
         """
-        return self.getRead(POZYX_QUAT_W, quaternion, remote_id)
+        res = self.getRead(POZYX_QUAT_W, quaternion, remote_id)
+        if res == POZYX_SUCCESS:
+            # Normalize quaternion
+            sum = sqrt(pow(quaternion.x,2)+ pow(quaternion.y,2) + pow(quaternion.z,2) + pow(quaternion.w,2))
+            quaternion.x/=sum
+            quaternion.y/=sum
+            quaternion.z/=sum
+            quaternion.w/=sum
+        return res
 
     def getLinearAcceleration_mg(self, linear_acceleration, remote_id=None):
         """

--- a/pypozyx/lib.py
+++ b/pypozyx/lib.py
@@ -1142,6 +1142,30 @@ class PozyxLib(PozyxCore):
         """
         return self.getRead(POZYX_EUL_HEADING, euler_angles, remote_id)
 
+
+    def getNormalizedQuaternion(self, quaternion, remote_id=None):
+        """
+        Obtain the Pozyx's normalized quaternion sensor data that is required for ROS.
+
+        Args:
+            quaternion: Container for the read data. Quaternion().
+
+        Kwargs:
+            remote_id: Remote Pozyx ID.
+
+        Returns:
+            POZYX_SUCCESS, POZYX_FAILURE, POZYX_TIMEOUT
+        """
+        res = self.getQuaternion(quaternion,remote_id)
+        if res == POZYX_SUCCESS:
+            # Normalize quaternion
+            sum = sqrt(pow(quaternion.x,2)+ pow(quaternion.y,2) + pow(quaternion.z,2) + pow(quaternion.w,2))
+            quaternion.x/=sum
+            quaternion.y/=sum
+            quaternion.z/=sum
+            quaternion.w/=sum
+        return res
+        
     def getQuaternion(self, quaternion, remote_id=None):
         """
         Obtain the Pozyx's quaternion sensor data.
@@ -1155,15 +1179,8 @@ class PozyxLib(PozyxCore):
         Returns:
             POZYX_SUCCESS, POZYX_FAILURE, POZYX_TIMEOUT
         """
-        res = self.getRead(POZYX_QUAT_W, quaternion, remote_id)
-        if res == POZYX_SUCCESS:
-            # Normalize quaternion
-            sum = sqrt(pow(quaternion.x,2)+ pow(quaternion.y,2) + pow(quaternion.z,2) + pow(quaternion.w,2))
-            quaternion.x/=sum
-            quaternion.y/=sum
-            quaternion.z/=sum
-            quaternion.w/=sum
-        return res
+        return self.getRead(POZYX_QUAT_W, quaternion, remote_id)
+  
 
     def getLinearAcceleration_mg(self, linear_acceleration, remote_id=None):
         """

--- a/pypozyx/pozyx_serial.py
+++ b/pypozyx/pozyx_serial.py
@@ -7,7 +7,7 @@ from pypozyx.lib import PozyxLib
 from pypozyx.structures.generic import Data, SingleRegister
 from serial import Serial
 from serial.tools.list_ports import comports
-
+import os
 ## \addtogroup auxiliary_serial
 # @{
 
@@ -72,11 +72,15 @@ class PozyxSerial(PozyxLib):
         """Initializes the PozyxSerial object. See above for details."""
         self.print_output = print_output
         try:
-            self.ser = Serial(port, baudrate, timeout=timeout,
+            if os.name == "posix":
+                self.ser = Serial(port, baudrate, timeout=timeout)
+            else:
+                self.ser = Serial(port, baudrate, timeout=timeout,
                               write_timeout=write_timeout)
-        except:
+        except Exception as exc:
             print(
                 "Couldn't connect with Pozyx, wrong/busy serial port, or pySerial not installed.")
+            print str(exc)
             if debug_trace:
                 import traceback
                 import sys


### PR DESCRIPTION
checking OS in init to handle the serial port differently.
printed exception, as the default error message was misleading.