### PR TITLE
Fix switch of operation modes values (closes #48)

### DIFF
--- a/pypozyx/definitions/constants.py
+++ b/pypozyx/definitions/constants.py
@@ -54,8 +54,8 @@ class PozyxConstants:
     LED_OFF = False
 
     # Pozyx device modes
-    ANCHOR_MODE = 0
-    TAG_MODE = 1
+    TAG_MODE = 0
+    ANCHOR_MODE = 1
 
     # The GPIO modes
     GPIO_DIGITAL_INPUT = 0


### PR DESCRIPTION
The Operation mode registry (0x22) contains 0 when the jumper sets the device as a Tag and contains 1 when the jumper sets the device as an anchor. Therefore, the constants are switched in the library to match the behavior of the device.