### PR TITLE
byte_structure: correctly compare with None

### DIFF
--- a/pypozyx/structures/byte_structure.py
+++ b/pypozyx/structures/byte_structure.py
@@ -109,6 +109,8 @@ class ByteStructure(object):
 
     def __eq__(self, other):
         """Returns whether the structures contain the same data"""
+        if other is None:
+            return False
         return self.data == other.data and self.data_format == other.data_format
 
     def __str__(self):


### PR DESCRIPTION
The `bytes_structure` class will crash when using `==` to compare with `None`. This fixes that.