### PR TITLE
Fix automatic installation of dependencies.

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -20,7 +20,7 @@ import sys
 import os
 sys.path.append(os.path.join(os.path.dirname(__name__), '..'))
 
-from pypozyx import VERSION as PYPOZYX_VERSION
+from version import VERSION as PYPOZYX_VERSION
 
 
 # -- Project information -----------------------------------------------------

--- a/pypozyx/__init__.py
+++ b/pypozyx/__init__.py
@@ -72,11 +72,6 @@ switch at some point.
 
 """
 
-__version__ = '1.3.0'
-
-VERSION = __version__
-version = __version__
-
 
 from pypozyx.definitions import *
 from pypozyx.pozyx_serial import *

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from os import path
 from setuptools import setup
 from codecs import open
 
-from pypozyx import VERSION as PYPOZYX_VERSION
+from version import VERSION as PYPOZYX_VERSION
 
 here = path.abspath(path.dirname(__file__))
 # Get the long description from the README file

--- a/version.py
+++ b/version.py
@@ -1,0 +1,4 @@
+__version__ = '1.3.0'
+
+VERSION = __version__
+version = __version__


### PR DESCRIPTION
Currently, `setup.py` imports the `__init__.py` file to get the package version; this prevents the automatic installation of pyserial, giving the following error if it is not manually installed before pypozyx:
```
Traceback (most recent call last):
    ...
    from serial import Serial, VERSION as PYSERIAL_VERSION, SerialException, line 10, in <module>
ModuleNotFoundError: No module named 'serial'
```
This patch moves the definition of the version string to a separate file, avoiding dependency imports during installation.