### PR TITLE
Fix warnings in setConfigGPIO()

### DIFF
--- a/pypozyx/lib.py
+++ b/pypozyx/lib.py
@@ -190,9 +190,9 @@ class PozyxLib(PozyxCore):
 
         if not 1 <= gpio_num <= 4:
             warn("setConfigGPIO: GPIO number {} not in range".format(gpio_num))
-        if mode[0] in PozyxConstants.ALL_GPIO_MODES:
+        if mode[0] not in PozyxConstants.ALL_GPIO_MODES:
             warn("setConfigGPIO: {} wrong GPIO mode".format(mode[0]))
-        if pull[0] in PozyxConstants.ALL_GPIO_PULLS:
+        if pull[0] not in PozyxConstants.ALL_GPIO_PULLS:
             warn("setConfigGPIO: {} wrong GPIO pull".format(pull[0]))
 
         gpio_register = PozyxRegisters.CONFIG_GPIO_1 + gpio_num - 1


### PR DESCRIPTION
There was wrong (opposite) condition for given warnings:
```
>>> mode.value = pypozyx.PozyxConstants.GPIO_DIGITAL_INPUT
>>> pull.value = pypozyx.PozyxConstants.GPIO_PULL_UP
>>> pozyx.setConfigGPIO(1, mode, pull, 0xD53)
/home/md/.virtualenvs/osgar/lib/python3.8/site-packages/pypozyx/lib.py:194: UserWarning: setConfigGPIO: 0 wrong GPIO mode
  warn("setConfigGPIO: {} wrong GPIO mode".format(mode[0]))
/home/md/.virtualenvs/osgar/lib/python3.8/site-packages/pypozyx/lib.py:196: UserWarning: setConfigGPIO: 1 wrong GPIO pull
  warn("setConfigGPIO: {} wrong GPIO pull".format(pull[0]))
1
```
but this functions seems to be working fine ...

Complete code and comments at [robotika.cz/articles/pozyx/cs#230108](https://robotika.cz/articles/pozyx/cs#230108)